### PR TITLE
Implemented rule to avoid duplicates

### DIFF
--- a/src/Analyzer.Legacy/Analyzer.Legacy.csproj
+++ b/src/Analyzer.Legacy/Analyzer.Legacy.csproj
@@ -55,8 +55,9 @@
     <Compile Include="..\Analyzer\Rules\MustBeSealed.cs" Link="Rules\MustBeSealed.cs" />
     <Compile Include="..\Analyzer\Rules\MustHaveSinglePrivateConstructor.cs" Link="Rules\MustHaveSinglePrivateConstructor.cs" />
     <Compile Include="..\Analyzer\Rules\MustHaveStaticLogFieldOrProperty.cs" Link="Rules\MustHaveStaticLogFieldOrProperty.cs" />
-    <Compile Include="..\Analyzer\Rules\MustHaveValidName.cs" Link="Rules\MustHaveValidName.cs" />
-    <Compile Include="..\Analyzer\Rules\RequiredRuleSet.cs" Link="Rules\RequiredRuleSet.cs" />
+	<Compile Include="..\Analyzer\Rules\MustHaveUniqueEventId.cs" Link="Rules\MustHaveUniqueEventId.cs" />
+	<Compile Include="..\Analyzer\Rules\MustHaveValidName.cs" Link="Rules\MustHaveValidName.cs" />
+	<Compile Include="..\Analyzer\Rules\RequiredRuleSet.cs" Link="Rules\RequiredRuleSet.cs" />
     <Compile Include="..\Analyzer\Rules\Success.cs" Link="Rules\Success.cs" />
     <Compile Include="..\Analyzer\SchemaCache.cs" Link="SchemaCache.cs" />
     <Compile Include="..\Analyzer\SchemaReader.cs" Link="SchemaReader.cs" />

--- a/src/Analyzer.Tests/EventSources/NonUniqueEventIdEventSource.cs
+++ b/src/Analyzer.Tests/EventSources/NonUniqueEventIdEventSource.cs
@@ -1,0 +1,39 @@
+﻿using System.Diagnostics.Tracing;
+
+namespace Thor.Analyzer.Tests.EventSources
+{
+    [EventSource(Name = "NonUniqueEventId")]
+    public class NonUniqueEventIdEventSource
+        : EventSource
+    {
+        [Event(1)]
+        public void Foo1a(string bar)
+        {
+            WriteEvent(1, bar);
+        }
+
+        [Event(1)]
+        public void Foo1b(string bar)
+        {
+            WriteEvent(1, bar);
+        }
+
+        [Event(2)]
+        public void Foo2a(string bar)
+        {
+            WriteEvent(1, bar);
+        }
+
+        [Event(2)]
+        public void Foo2b(string bar)
+        {
+            WriteEvent(1, bar);
+        }
+
+        [Event(2)]
+        public void Foo2c(string bar)
+        {
+            WriteEvent(1, bar);
+        }
+    }
+}

--- a/src/Analyzer.Tests/EventSources/UniqueEventIdEventSource.cs
+++ b/src/Analyzer.Tests/EventSources/UniqueEventIdEventSource.cs
@@ -1,0 +1,39 @@
+﻿using System.Diagnostics.Tracing;
+
+namespace Thor.Analyzer.Tests.EventSources
+{
+    [EventSource(Name = "NonUniqueEventId")]
+    public class UniqueEventIdEventSource
+        : EventSource
+    {
+        [Event(11)]
+        public void Foo1a(string bar)
+        {
+            WriteEvent(1, bar);
+        }
+
+        [Event(12)]
+        public void Foo1b(string bar)
+        {
+            WriteEvent(1, bar);
+        }
+
+        [Event(21)]
+        public void Foo2a(string bar)
+        {
+            WriteEvent(1, bar);
+        }
+
+        [Event(22)]
+        public void Foo2b(string bar)
+        {
+            WriteEvent(1, bar);
+        }
+
+        [Event(23)]
+        public void Foo2c(string bar)
+        {
+            WriteEvent(1, bar);
+        }
+    }
+}

--- a/src/Analyzer.Tests/Rules/MustHaveUniqueEventId.cs
+++ b/src/Analyzer.Tests/Rules/MustHaveUniqueEventId.cs
@@ -1,0 +1,53 @@
+﻿using Thor.Analyzer.Rules;
+using Thor.Analyzer.Tests.EventSources;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Thor.Analyzer.Tests.Rules
+{
+    public class MustHaveUniqueEventIdTests
+        : EventSourceRuleTestBase<MustHaveUniqueEventId>
+    {
+        protected override MustHaveUniqueEventId CreateRule(IRuleSet ruleSet)
+        {
+            return new MustHaveUniqueEventId(ruleSet);
+        }
+
+        [Fact(DisplayName = "Apply: Should return an error if event source has non-unique event identifiers")]
+        public void Apply_NonUniqueEventId()
+        {
+            // arrange
+            NonUniqueEventIdEventSource eventSource = new NonUniqueEventIdEventSource();
+            SchemaReader reader = new SchemaReader(eventSource);
+            EventSourceSchema schema = reader.Read();
+            IRuleSet ruleSet = new Mock<IRuleSet>().Object;
+            IEventSourceRule rule = CreateRule(ruleSet);
+
+            // act
+            IResult result = rule.Apply(schema, eventSource);
+
+            // assert
+            result.Should().NotBeNull();
+            result.Should().BeOfType<Error>();
+        }
+
+        [Fact(DisplayName = "Apply: Should return a success if event source has unique event identifiers")]
+        public void Apply_UniqueEventId()
+        {
+            // arrange
+            UniqueEventIdEventSource eventSource = new UniqueEventIdEventSource();
+            SchemaReader reader = new SchemaReader(eventSource);
+            EventSourceSchema schema = reader.Read();
+            IRuleSet ruleSet = new Mock<IRuleSet>().Object;
+            IEventSourceRule rule = CreateRule(ruleSet);
+
+            // act
+            IResult result = rule.Apply(schema, eventSource);
+
+            // assert
+            result.Should().NotBeNull();
+            result.Should().BeOfType<Success>();
+        }
+    }
+}

--- a/src/Analyzer/EventSourceExtensions.cs
+++ b/src/Analyzer/EventSourceExtensions.cs
@@ -13,8 +13,9 @@ namespace Thor.Analyzer
 {
     internal static class EventSourceExtensions
     {
-        private const BindingFlags _bindings = BindingFlags.Instance | BindingFlags.DeclaredOnly |
-            BindingFlags.InvokeMethod | BindingFlags.NonPublic | BindingFlags.Public;
+        private const BindingFlags _bindings = 
+            BindingFlags.Instance | BindingFlags.DeclaredOnly | BindingFlags.InvokeMethod | 
+            BindingFlags.NonPublic | BindingFlags.Public;
 
         public static MethodInfo GetMethodFromSchema(this EventSource eventSource,
             EventSchema schema)

--- a/src/Analyzer/EventSourceExtensions.cs
+++ b/src/Analyzer/EventSourceExtensions.cs
@@ -46,9 +46,12 @@ namespace Thor.Analyzer
 
         public static bool IsEvent(this MethodInfo method, int eventId)
         {
-            EventAttribute attribute = method.GetEvent();
-            return method.GetCustomAttribute<EventAttribute>() != null &&
-                method.GetCustomAttribute<EventAttribute>().EventId == eventId;
+            if (method == null)
+            {
+                throw new ArgumentNullException(nameof(method));
+            }
+
+            return method.GetEvent()?.EventId == eventId;
         }
 
         public static EventAttribute GetEvent(this MethodInfo method)

--- a/src/Analyzer/Rules/BestPracticeRuleSet.cs
+++ b/src/Analyzer/Rules/BestPracticeRuleSet.cs
@@ -18,6 +18,7 @@ namespace Thor.Analyzer.Rules
                 new MustBeSealed(this),
                 new MustHaveSinglePrivateConstructor(this),
                 new MustHaveStaticLogFieldOrProperty(this),
+                new MustHaveUniqueEventId(this),
                 new MustHaveValidName(this)
             };
         }

--- a/src/Analyzer/Rules/MustHaveUniqueEventId.cs
+++ b/src/Analyzer/Rules/MustHaveUniqueEventId.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using System.Reflection;
+using System.Linq;
+using System.Collections.Generic;
+
+#if LEGACY
+using Microsoft.Diagnostics.Tracing;
+#else
+using System.Diagnostics.Tracing;
+#endif
+
+namespace Thor.Analyzer.Rules
+{
+    /// <summary>
+    /// A rule which verifies if the event source has unique event identifiers.
+    /// </summary>
+    public class MustHaveUniqueEventId
+        : IEventSourceRule
+    {
+        private static Regex _namePattern = new Regex(@"^[a-zA-Z]+(\-[a-zA-Z]+)*$",
+            RegexOptions.Compiled | RegexOptions.Singleline);
+
+        /// <summary>
+        /// Initiates a new instance of the <see cref="MustHaveUniqueEventId"/> class.
+        /// </summary>
+        /// <param name="ruleSet">A ruleset which is the parent of this rule.</param>
+        public MustHaveUniqueEventId(IRuleSet ruleSet)
+        {
+            if (ruleSet == null)
+            {
+                throw new ArgumentNullException(nameof(ruleSet));
+            }
+
+            RuleSet = ruleSet;
+        }
+
+        /// <inheritdoc/>
+        public IRuleSet RuleSet { get; }
+
+        /// <inheritdoc/>
+        public IResult Apply(EventSourceSchema schema, EventSource eventSource)
+        {
+            if (schema == null)
+            {
+                throw new ArgumentNullException(nameof(schema));
+            }
+            if (eventSource == null)
+            {
+                throw new ArgumentNullException(nameof(eventSource));
+            }
+
+            Type eventSourceType = eventSource.GetType();
+            var attributeMap = eventSource
+                .GetMethods()
+                .Select(mi => new
+                {
+                    MethodInfo = mi,
+                    EventAttribute = mi.GetEvent()
+                })
+                .Where(mi => mi.EventAttribute != null);
+
+            var duplicates = attributeMap
+                .GroupBy(map => map.EventAttribute.EventId)
+                .Where(g => g.Count() > 1)
+                .ToDictionary(
+                    k => k.Key,
+                    v => v.Select(s => s.MethodInfo.Name).ToArray());
+
+            if(duplicates.Any())
+            {
+                string duplicatesString = string.Join(
+                    " / ",
+                    duplicates.Select(dup => $"[{dup.Key}] -> [{string.Join(", ", dup.Value)}]"));
+                
+                return new Error(
+                    this,
+                    "The EventSource must have unique event identifiers. " +
+                    $"Duplicates: {duplicatesString}");
+            }
+
+            if (!_namePattern.IsMatch(schema.ProviderName))
+            {
+                return new Error(this, "The EventSource must have a valid name.");
+            }
+
+            return new Success(this);
+        }
+
+        private object GetDuplicatesString(Dictionary<int, string[]> duplicates)
+        {
+
+            string result = string.Empty;
+            foreach(var dup in duplicates)
+            {
+                result += $"{dup.Key} in [{string.Join(", ", dup.Value)}] ";
+            }
+            return result;
+        }
+    }
+}

--- a/src/Analyzer/Rules/MustHaveUniqueEventId.cs
+++ b/src/Analyzer/Rules/MustHaveUniqueEventId.cs
@@ -86,16 +86,5 @@ namespace Thor.Analyzer.Rules
 
             return new Success(this);
         }
-
-        private object GetDuplicatesString(Dictionary<int, string[]> duplicates)
-        {
-
-            string result = string.Empty;
-            foreach(var dup in duplicates)
-            {
-                result += $"{dup.Key} in [{string.Join(", ", dup.Value)}] ";
-            }
-            return result;
-        }
     }
 }


### PR DESCRIPTION
The current Thor implementation silently swallows all events that are passed into an event-method that has a non-unique event identifier. The changes in this PR should detect this issue within an event source:
```csharp
    [EventSource(Name = "NonUniqueEventId")]
    public class NonUniqueEventIdEventSource
        : EventSource
    {
        [Event(1)] // <-- Duplicate here...
        public void Foo1a(string bar)
        {
            WriteEvent(1, bar);
        }

        [Event(1)] // <-- Duplicate here...
        public void Foo1b(string bar)
        {
            WriteEvent(1, bar);
        }
}
 ```